### PR TITLE
[module/Common] feat: BaseNetworkManager 구현

### DIFF
--- a/Common/Common/Network/NetworkManager.swift
+++ b/Common/Common/Network/NetworkManager.swift
@@ -23,3 +23,22 @@ public struct NetworkManager<Target: TargetType, DTO: Decodable> {
 
     }
 }
+
+open class BaseNetworkManager<Target : TargetType>{
+    let provider = MoyaProvider<Target>()
+    
+    public init() {}
+    
+    public func request<DTO: Decodable>(_ type: Target) -> Single<Result<SuccessDTO<DTO>, Error>> {
+        return provider.rx.request(type)
+            .map {
+                let response = try $0.map(ResponseDTO<DTO>.self)
+                if response.success {
+                    return .success(SuccessDTO(code: $0.statusCode, data: response.data))
+                }
+                else{
+                    return .failure(response.error!)
+                }
+            }
+    }
+}

--- a/Common/Common/Network/ResponseDTO.swift
+++ b/Common/Common/Network/ResponseDTO.swift
@@ -14,7 +14,12 @@ struct ResponseDTO<CommonDataDTO: Decodable> : Decodable {
     
 }
 
-struct ErrorDTO : Decodable, Error {
+public struct ErrorDTO : Decodable, Error {
     let code : Int
     let message: String
+}
+
+public struct SuccessDTO<DTO: Decodable> {
+    public let code: Int
+    public let data: DTO?
 }


### PR DESCRIPTION

### 작업 내용

rxMoya를 사용하여 BaseNetworkManager를 개발했습니다.
제네릭하게 Target을 받아서 class를 사용하고, 제네릭하게 DTO를 받아서 request 함수를 사용할 수 있습니다.
네트워크로직이 필요한 모듈에서는 BaseNetworkManager를 상속하여 코드의 중복을 최소화 하여 각각의 request 함수를 개발할 수 있습니다.